### PR TITLE
APPENG-11670: Fix Prefix being removed after post is moved.

### DIFF
--- a/plugins/PrefixDiscussion/class.prefixdiscussion.plugin.php
+++ b/plugins/PrefixDiscussion/class.prefixdiscussion.plugin.php
@@ -189,10 +189,10 @@ class PrefixDiscussionPlugin extends Gdn_Plugin {
         if ($prefix == '') {
             return;
         }
-        
+
         // Purify the prefix.
         $prefix = Gdn_Format::plainText($prefix);
-        
+
         $sender->addCssFile('prefixdiscussion.css', 'plugins/prefixDiscussion');
         $sender->setData(
             'Discussion.Name',
@@ -226,10 +226,10 @@ class PrefixDiscussionPlugin extends Gdn_Plugin {
         if ($prefix == '') {
             return;
         }
-        
+
         // Purify the prefix.
         $prefix = Gdn_Format::plainText($prefix);
-        
+
         $args['Discussion']->Name = wrap(
             $prefix,
             'span',
@@ -274,6 +274,10 @@ class PrefixDiscussionPlugin extends Gdn_Plugin {
      * @return  void.
      */
     public function discussionModel_beforeSaveDiscussion_handler($sender, $args) {
+        if(!isset($args['FormPostValues']['Prefix'])) {
+            $args['FormPostValues']['Prefix'] = $args['discussion']['Prefix'];
+        }
+
         if (!in_array($args['FormPostValues']['Prefix'], self::getPrefixes())) {
             $args['FormPostValues']['Prefix'] = null;
         }


### PR DESCRIPTION
# Issue 

The discussion prefix is getting removed when the post is moved to a different category.

See: https://higherlogic.atlassian.net/browse/APPENG-11670

# Solution

This issue was caused by `FormPostValues` not being set when the post was moved. Adding a check that will set the value of the discussion when this value is not set will ensure it gets a value assigned to it if one exists.

# How to test

1) Enable this plugin.
2) Assign a Prefix to a post using the edit function.
3) Move the post to a different category  
4) Confirm that the prefix is gone.
5) Checkout this branch
6) Redo steps 2-3, confirm that the prefix remains.
